### PR TITLE
Updates for nodejs 0.6.x and express 2.5.x compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Then I caught a talk on the `node.js`_ server, and saw a way.
 
 In my environment, this cuts jslint invocation time in half.
 
-This project also depends on the Express_ framework, with the connect-form, underscore
+This project also depends on the Express_ framework, with the underscore
 and haml packages.  I recommend installation with npm_ to manage these
 dependencies.
 

--- a/app.js
+++ b/app.js
@@ -5,11 +5,12 @@
 
    Invoke from bash script like:
 
-     curl --form source="<${1}" ${JSLINT_URL}
+     curl --form source="<${1}" --form filename="${1}" ${JSLINT_URL}
+     
+   or use the provided jslint.curl
+   
+     jslint.curl <file>
 
-   If you use source="@${1}" instead, curl does it like a file upload.
-   That includes a filename, which is nice, but has express make a
-   temp file for the upload.
 */
 
 /*global process, require */
@@ -21,7 +22,6 @@ var _ = require('underscore');
 var app = express.createServer();
 
 app.configure(function () {
-    app.use(require('connect-form')({keepExtensions: true}));
     app.use(express.errorHandler(
         { dumpExceptions: true, showStack: true }));
     app.use(express.bodyParser());

--- a/app.js
+++ b/app.js
@@ -16,7 +16,6 @@
 var express = require("express");
 var JSLINT = require('./fulljslint');
 var fs = require('fs');
-var sys = require('sys');
 var _ = require('underscore');
 
 var app = express.createServer();
@@ -25,7 +24,7 @@ app.configure(function () {
     app.use(require('connect-form')({keepExtensions: true}));
     app.use(express.errorHandler(
         { dumpExceptions: true, showStack: true }));
-    app.use(express.bodyDecoder());
+    app.use(express.bodyParser());
 });
 
 var jslint_port = 3003;
@@ -141,7 +140,7 @@ function parseCommandLine() {
         exclude_opts = process.argv[exclude_index + 1].split(",");
         if (exclude_opts.length > 0 && exclude_opts[0] !== '') {
             _.each(exclude_opts, function (opt) {
-                sys.puts("Turning off " + opt);
+                console.log("Turning off " + opt);
                 jslint_options[opt] = false;
             });
         }
@@ -150,14 +149,14 @@ function parseCommandLine() {
         include_opts = process.argv[include_index + 1].split(",");
         if (include_opts.length > 0 && include_opts[0] !== '') {
             _.each(include_opts, function (opt) {
-                sys.puts("Turning on " + opt);
+                console.log("Turning on " + opt);
                 jslint_options[opt] = true;
             });
         }
     }
 }
 
-sys.puts("Starting lintnode server");
+console.log("Starting lintnode server");
 parseCommandLine();
 app.listen(jslint_port);
-sys.puts("Lintnode server running on port " + jslint_port);
+console.log("Lintnode server running on port " + jslint_port);

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
         "url": "http://keturn.net/"
     },
     "dependencies": {
-        "express": ">=1.0.0rc3 <2.0.0",
+        "express": ">=2.5.0",
         "haml": ">=0.2.0",
         "connect-form": ">= 0.1.2",
         "underscore": ""
     },
-    "engines": ["node >= 0.2.0"]
+    "engines": ["node >= 0.6.0"]
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "dependencies": {
         "express": ">=2.5.0",
         "haml": ">=0.2.0",
-        "connect-form": ">= 0.1.2",
         "underscore": ""
     },
     "engines": ["node >= 0.6.0"]


### PR DESCRIPTION
Hello David,

i updated lintnode to use `express >= 2.5.0` with `connect >= 1.0.0`, replaced `connect-form` with `connect.bodyParser` and removed file upload handling.

For nodejs 0.6.x compatibility i replaced `sys.puts` with `console.log`.

Regards,
Malte
