### PR TITLE
Allow setting of non-boolean options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,10 @@ e.g.
 
 $ node app.js --exclude nomen,undef
 
+or
+
+$ node app.js --set maxlen:80,node
+
 Alternatively they can be configured within emacs by setting the variable lintnode-jslint-excludes
 
 For documentation on JSLint's options, see `JSLint

--- a/app.js
+++ b/app.js
@@ -65,7 +65,7 @@ var outputErrors = function (errors) {
 };
 
 app.get('/', function (req, res) {
-    res.render('upload.haml');
+    res.send('lintnode');
 });
 
 app.post('/jslint', function (req, res) {
@@ -73,14 +73,13 @@ app.post('/jslint', function (req, res) {
         var passed, results;
         passed = JSLINT.JSLINT(sourcedata, jslint_options);
         if (passed) {
-            results = "jslint: No problems found in " + filename + "\n";
+            results = "jslint: No problems found in " + req.body.filename + "\n";
         } else {
             results = outputErrors(JSLINT.JSLINT.errors);
         }
         return results;
     }
-    res.writeHead(200, {'Content-Type': 'text/plain'});
-    res.end(doLint(req.body.source));
+    res.send(doLint(req.body.source), {'Content-Type': 'text/plain'});
 });
 
 /* This action always return some JSLint problems. */
@@ -94,13 +93,11 @@ var exampleFunc = function (req, res) {
 app.get('/example/errors', exampleFunc);
 app.post('/example/errors', exampleFunc);
 
-
 /* This action always returns JSLint's a-okay message. */
 app.post('/example/ok', function (req, res) {
     res.send("jslint: No problems found in example.js\n",
         {'Content-Type': 'text/plain'});
 });
-
 
 function parseCommandLine() {
     var port_index, exclude_index, exclude_opts, include_index, include_opts, set_index, set_opts, set_pair, properties;

--- a/app.js
+++ b/app.js
@@ -103,10 +103,11 @@ app.post('/example/ok', function (req, res) {
 
 
 function parseCommandLine() {
-    var port_index, exclude_index, exclude_opts, include_index, include_opts;
+    var port_index, exclude_index, exclude_opts, include_index, include_opts, set_index, set_opts, set_pair, properties;
     port_index = process.argv.indexOf('--port');
     exclude_index = process.argv.indexOf('--exclude');
     include_index = process.argv.indexOf('--include');
+    set_index = process.argv.indexOf('--set');
     if (port_index > -1) {
         jslint_port = process.argv[port_index + 1];
     }
@@ -114,7 +115,6 @@ function parseCommandLine() {
         exclude_opts = process.argv[exclude_index + 1].split(",");
         if (exclude_opts.length > 0 && exclude_opts[0] !== '') {
             _.each(exclude_opts, function (opt) {
-                console.log("Turning off " + opt);
                 jslint_options[opt] = false;
             });
         }
@@ -123,14 +123,41 @@ function parseCommandLine() {
         include_opts = process.argv[include_index + 1].split(",");
         if (include_opts.length > 0 && include_opts[0] !== '') {
             _.each(include_opts, function (opt) {
-                console.log("Turning on " + opt);
                 jslint_options[opt] = true;
             });
         }
     }
+    if (set_index > -1) {
+        set_opts = process.argv[set_index + 1].split(",");
+        if (set_opts.length > 0 && set_opts[0] !== '') {
+            _.each(set_opts, function (opt) {
+                if (opt.indexOf(":") > -1) {
+                    set_pair = opt.split(":");
+                    if (set_pair[1] === "true") {
+                        set_pair[1] = true;
+                    } else if (set_pair[1] === "false") {
+                        set_pair[1] = false;
+                    }
+                    jslint_options[set_pair[0]] = set_pair[1];
+                } else {
+                    jslint_options[opt] = true;
+                }
+            });
+        }
+    }
+    properties = "";
+    _.each(jslint_options, function (value, opt) {
+        properties = properties + opt + ": " + value + ", ";
+    });
+    return properties.substring(0, properties.length-2);
 }
 
-console.log("Starting lintnode server");
-parseCommandLine();
-app.listen(jslint_port);
-console.log("Lintnode server running on port " + jslint_port);
+process.on('SIGINT', function () {
+    console.log("\n[lintnode] received SIGINT, shutting down");
+    process.exit(0);
+});
+
+console.log("[lintnode]", parseCommandLine());
+app.listen(jslint_port, function () {
+    console.log("[lintnode] server running on port", jslint_port);
+});

--- a/flymake-jslint.el
+++ b/flymake-jslint.el
@@ -56,6 +56,8 @@
 
 (defvar lintnode-jslint-includes nil)
 
+(defvar lintnode-jslint-set nil)
+
 (defun lintnode-start ()
   "Start the lintnode server.
 Uses `lintnode-node-program' and `lintnode-location'."
@@ -68,12 +70,14 @@ Uses `lintnode-node-program' and `lintnode-location'."
 		(lintnode-includes (if (not lintnode-jslint-includes)
                                ""
                              (mapconcat 'identity (mapcar 'symbol-name lintnode-jslint-includes) ","))))
+					   
     (start-process "lintnode-server" "*lintnode*"
                    lintnode-node-program
                    lintnode-location
                    "--port" (number-to-string lintnode-port)
                    "--exclude" lintnode-excludes
-				   "--include" lintnode-includes)))
+				   "--include" lintnode-includes
+				   "--set" lintnode-jslint-set)))
 
 (defun lintnode-stop ()
   "stop the lintnode server process"

--- a/flymake-jslint.el
+++ b/flymake-jslint.el
@@ -52,11 +52,14 @@
   :type 'boolean
   :group 'flymake-jslint)
 
-(defvar lintnode-jslint-excludes nil)
+(defvar lintnode-jslint-excludes nil
+  "a list of lisp symbols corresponding to jslint boolean options")
 
-(defvar lintnode-jslint-includes nil)
+(defvar lintnode-jslint-includes nil
+  "a list of lisp symbols corresponding to jslint boolean options")
 
-(defvar lintnode-jslint-set nil)
+(defvar lintnode-jslint-set nil
+  "a string of comma seperated jslint options; values are seperated via colon, e.g. maxlen:80,node:true,eqeqeq:false")
 
 (defun lintnode-start ()
   "Start the lintnode server.


### PR DESCRIPTION
Hello David,

a small addition to allow setting of non-boolean options, e.g. `node app.js --set maxlen:80,regexp:false,node`.
Also added cumulated jslint options output to command-line.

I left `--include` & `--exclude` untouched, although they are not really needed anymore.

Thanks for the quick response on my last pull request.

Regards,
Malte
